### PR TITLE
Add Likelihood for receive ics position

### DIFF
--- a/src/arcsys2_control/src/arcsys2_control_node.cpp
+++ b/src/arcsys2_control/src/arcsys2_control_node.cpp
@@ -52,6 +52,7 @@ private:
   JointData data_;
   ics::ICS3& driver_;
   ics::ID id_;
+  double last_pos_;
 };
 
 class DCMotorControl
@@ -178,19 +179,20 @@ int main(int argc, char *argv[])
 inline ICSControl::ICSControl(BuildDataType& build_data, ics::ICS3& driver, const ics::ID& id)
   : data_ {build_data.joint_name_},
     driver_(driver), // for ubuntu 14.04
-    id_ {id}
+    id_ {id},
+    last_pos_ {0}
 {
   registerJoint(data_, build_data);
 }
 
 inline void ICSControl::fetch()
 {
-  data_.pos_ = driver_.move(id_, ics::Angle::newRadian(data_.cmd_));
+  data_.pos_ = last_pos_;
 }
 
 inline void ICSControl::move()
 {
-  driver_.move(id_, ics::Angle::newRadian(data_.cmd_));
+  last_pos_ = driver_.move(id_, ics::Angle::newRadian(data_.cmd_)) / 2 + last_pos_ / 2;
 }
 
 inline DCMotorControl::DCMotorControl(BuildDataType& build_data)


### PR DESCRIPTION
ICSのポジションを過去の値を用いて推測するように変更。この世で最も簡単な方法である `(now + last) / 2` 漸化式を使用。

体感的に言うと、これを適用する前は動かない確率が0.9だったのに対して、こちらは0.3ほどにまで落ちたかと思います。(つまり0.01 [rad]以上currentからずれている確率)