### PR TITLE
Fix dependency for controller and controllers

### DIFF
--- a/src/arcsys2_control/package.xml
+++ b/src/arcsys2_control/package.xml
@@ -20,6 +20,8 @@
   <depend> hardware_interface </depend>
   <depend> nav_msgs           </depend>
   <exec_depend> joint_trajectory_controller </exec_depend>
-  <exec_depend> position_controller         </exec_depend>
+  <exec_depend> joint_state_controller      </exec_depend>
+  <exec_depend> position_controllers        </exec_depend>
+  <exec_depend> velocity_controllers        </exec_depend>
   <exec_depend> robot_state_publisher       </exec_depend>
 </package>


### PR DESCRIPTION
`controllers` と `controller` パッケージの区別がつかない人がいたみたいなので修正するついでに
`joint_state_controller`  と `velocity_controllers` を追加