### PR TITLE
Update arcsys2_bringup_*.launch

### DIFF
--- a/src/arcsys2_bringup/launch/arcsys2_bringup_all.launch
+++ b/src/arcsys2_bringup/launch/arcsys2_bringup_all.launch
@@ -1,14 +1,17 @@
 <launch>
 
-  <arg name="dammy" default="false" />
+  <arg name="dammy_controller" default="false" />
+  <arg name="dammy_sensor"     default="false" />
 
   <include file="$(find arcsys2_bringup)/launch/arcsys2_bringup_description.launch" />
 
   <include file="$(find arcsys2_bringup)/launch/arcsys2_bringup_controller.launch">
-    <arg name="dammy" value="$(arg dammy)" />
+    <arg name="dammy" value="$(arg dammy_controller)" />
   </include>
 
-  <include file="$(find arcsys2_bringup)/launch/arcsys2_bringup_sensor.launch" />
+  <include file="$(find arcsys2_bringup)/launch/arcsys2_bringup_sensor.launch">
+    <arg name="dammy" value="$(arg dammy_sensor)" />
+  </include>
 
   <include file="$(find arcsys2_bringup)/launch/arcsys2_bringup_moveit.launch" />
 

--- a/src/arcsys2_bringup/launch/arcsys2_bringup_all.launch
+++ b/src/arcsys2_bringup/launch/arcsys2_bringup_all.launch
@@ -1,16 +1,16 @@
 <launch>
 
-  <arg name="dammy_controller" default="false" />
-  <arg name="dammy_sensor"     default="false" />
+  <arg name="dummy_controller" default="false" />
+  <arg name="dummy_sensor"     default="false" />
 
   <include file="$(find arcsys2_bringup)/launch/arcsys2_bringup_description.launch" />
 
   <include file="$(find arcsys2_bringup)/launch/arcsys2_bringup_controller.launch">
-    <arg name="dammy" value="$(arg dammy_controller)" />
+    <arg name="dummy" value="$(arg dummy_controller)" />
   </include>
 
   <include file="$(find arcsys2_bringup)/launch/arcsys2_bringup_sensor.launch">
-    <arg name="dammy" value="$(arg dammy_sensor)" />
+    <arg name="dummy" value="$(arg dummy_sensor)" />
   </include>
 
   <include file="$(find arcsys2_bringup)/launch/arcsys2_bringup_moveit.launch" />

--- a/src/arcsys2_bringup/launch/arcsys2_bringup_controller.launch
+++ b/src/arcsys2_bringup/launch/arcsys2_bringup_controller.launch
@@ -1,8 +1,8 @@
 <launch>
 
-  <arg name="dammy" default="false" />
-  <arg unless="$(arg dammy)" name="control_node" value="arcsys2_control_node" />
-  <arg     if="$(arg dammy)" name="control_node" value="arcsys2_dammy_hw_node" />
+  <arg name="dummy" default="false" />
+  <arg unless="$(arg dummy)" name="control_node" value="arcsys2_control_node" />
+  <arg     if="$(arg dummy)" name="control_node" value="arcsys2_dammy_hw_node" />
 
   <include file="$(find arcsys2_control)/launch/joint_state_controller.launch" />
   <include file="$(find arcsys2_control)/launch/joint_trajectory_controller.launch" />

--- a/src/arcsys2_bringup/launch/arcsys2_bringup_sensor.launch
+++ b/src/arcsys2_bringup/launch/arcsys2_bringup_sensor.launch
@@ -1,8 +1,8 @@
 <launch>
 
-  <arg name="dammy" default="false" />
+  <arg name="dummy" default="false" />
 
-  <group unless="$(arg dammy)">
+  <group unless="$(arg dummy)">
     <include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch">
       <arg name="reg_method" value="opencl" />
       <arg name="depth_method" value="opencl" />
@@ -18,8 +18,8 @@
     </node>
   </group>
 
-  <group if="$(arg dammy)">
-    <node name="kinect_tomato_broadcaster_dammy" pkg="tf2_ros" type="static_transform_publisher"
+  <group if="$(arg dummy)">
+    <node name="kinect_tomato_broadcaster_dummy" pkg="tf2_ros" type="static_transform_publisher"
           args="1.2 0 -0.5 0 0 0 1 kinect tomato" />
   </group>
 

--- a/src/arcsys2_bringup/launch/arcsys2_bringup_sensor.launch
+++ b/src/arcsys2_bringup/launch/arcsys2_bringup_sensor.launch
@@ -1,17 +1,26 @@
 <launch>
 
+  <arg name="debug" default="false" />
+
   <include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch">
     <arg name="reg_method" value="opencl" />
     <arg name="depth_method" value="opencl" />
   </include>
 
-  <include file="$(find kinect_tomato_searcher)/launch/kinect_tomato_searcher.launch">
-    <arg name="color_topic" value="kinect2/sd/image_color_rect" />
-    <arg name="depth_topic" value="kinect2/sd/image_depth_rect" />
-  </include>
+  <group unless="$(arg debug)">
+    <include file="$(find kinect_tomato_searcher)/launch/kinect_tomato_searcher.launch">
+      <arg name="color_topic" value="kinect2/sd/image_color_rect" />
+      <arg name="depth_topic" value="kinect2/sd/image_depth_rect" />
+    </include>
 
-  <node name="kinect_tomato_broadcaster_node" pkg="kinect_tomato_searcher" type="kinect_tomato_broadcaster_node">
-    <remap from="tomato_point" to="tomato_point/raw" />
-  </node>
+    <node name="kinect_tomato_broadcaster_node" pkg="kinect_tomato_searcher" type="kinect_tomato_broadcaster_node">
+      <remap from="tomato_point" to="tomato_point/raw" />
+    </node>
+  </group>
+
+  <group if="$(arg debug)">
+    <node name="kinect_tomato_broadcaster_dammy" pkg="tf2_ros" type="static_transform_publisher"
+          args="1.2 0 -0.5 0 0 0 1 kinect tomato" />
+  </group>
 
 </launch>

--- a/src/arcsys2_bringup/launch/arcsys2_bringup_sensor.launch
+++ b/src/arcsys2_bringup/launch/arcsys2_bringup_sensor.launch
@@ -1,13 +1,13 @@
 <launch>
 
-  <arg name="debug" default="false" />
+  <arg name="dammy" default="false" />
 
-  <include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch">
-    <arg name="reg_method" value="opencl" />
-    <arg name="depth_method" value="opencl" />
-  </include>
+  <group unless="$(arg dammy)">
+    <include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch">
+      <arg name="reg_method" value="opencl" />
+      <arg name="depth_method" value="opencl" />
+    </include>
 
-  <group unless="$(arg debug)">
     <include file="$(find kinect_tomato_searcher)/launch/kinect_tomato_searcher.launch">
       <arg name="color_topic" value="kinect2/sd/image_color_rect" />
       <arg name="depth_topic" value="kinect2/sd/image_depth_rect" />
@@ -18,7 +18,7 @@
     </node>
   </group>
 
-  <group if="$(arg debug)">
+  <group if="$(arg dammy)">
     <node name="kinect_tomato_broadcaster_dammy" pkg="tf2_ros" type="static_transform_publisher"
           args="1.2 0 -0.5 0 0 0 1 kinect tomato" />
   </group>

--- a/src/arcsys2_bringup/launch/tomato_dammy.launch
+++ b/src/arcsys2_bringup/launch/tomato_dammy.launch
@@ -1,3 +1,0 @@
-<launch>
-  <node pkg="tf2_ros" type="static_transform_publisher" name="tomato_dammy_broadcaster" args="1.2 0 -0.5 0 0 0 1 kinect tomato" />
-</launch>


### PR DESCRIPTION
arcsys2_bringup_all.launchにコントローラとセンサについてダミー指定が出来るよう改良しました
お納め下さい

なお我々がdummyという単語を盛大にスペルミスしているという事実が発覚したので今後は見つけしたい修正していく方向で
今わかっているのは`arcsys2_control arcsys2_dammy_hw_node`が間違ったままだということ
（ブランチ名から外れるので放置しました）